### PR TITLE
Panache and Hibernate Reactive use different Vert.x local contexts

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -159,7 +159,7 @@
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.3.0</awaitility.version>
         <jboss-logmanager.version>3.1.2.Final</jboss-logmanager.version>
-        <flyway.version>11.7.1</flyway.version>
+        <flyway.version>11.7.2</flyway.version>
         <yasson.version>3.0.4</yasson.version>
         <!-- liquibase-mongodb is not released everytime with liquibase anymore, but the two versions need to be compatible -->
         <liquibase.version>4.29.1</liquibase.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -50,7 +50,7 @@
         <smallrye-config.version>3.12.4</smallrye-config.version>
         <smallrye-health.version>4.2.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
-        <smallrye-open-api.version>4.0.9</smallrye-open-api.version>
+        <smallrye-open-api.version>4.0.10</smallrye-open-api.version>
         <smallrye-graphql.version>2.13.0</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.9.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.1</smallrye-jwt.version>

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/SessionOperations.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/SessionOperations.java
@@ -1,14 +1,11 @@
 package io.quarkus.hibernate.reactive.panache.common.runtime;
 
-import java.util.function.Function;
-import java.util.function.Supplier;
-
 import org.hibernate.reactive.common.spi.Implementor;
 import org.hibernate.reactive.context.Context.Key;
 import org.hibernate.reactive.context.impl.BaseKey;
+import org.hibernate.reactive.context.impl.ContextualDataStorage;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.mutiny.Mutiny.Session;
-import org.hibernate.reactive.mutiny.Mutiny.SessionFactory;
 import org.hibernate.reactive.mutiny.Mutiny.Transaction;
 
 import io.quarkus.arc.Arc;
@@ -16,8 +13,12 @@ import io.quarkus.arc.ClientProxy;
 import io.quarkus.arc.impl.LazyValue;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
 import io.smallrye.mutiny.Uni;
-import io.vertx.core.Context;
-import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.spi.context.storage.AccessMode;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Static util methods for {@link Mutiny.Session}.
@@ -26,32 +27,23 @@ public final class SessionOperations {
 
     private static final String ERROR_MSG = "Hibernate Reactive Panache requires a safe (isolated) Vert.x sub-context, but the current context hasn't been flagged as such.";
 
-    private static final LazyValue<Mutiny.SessionFactory> SESSION_FACTORY = new LazyValue<>(
-            new Supplier<Mutiny.SessionFactory>() {
-                @Override
-                public SessionFactory get() {
-                    // Note that Mutiny.SessionFactory is @ApplicationScoped bean - it's safe to use the cached client proxy
-                    Mutiny.SessionFactory sessionFactory = Arc.container().instance(Mutiny.SessionFactory.class).get();
-                    if (sessionFactory == null) {
-                        throw new IllegalStateException("Mutiny.SessionFactory bean not found");
-                    }
-                    return sessionFactory;
-                }
-            });
+    private static final LazyValue<Mutiny.SessionFactory> SESSION_FACTORY = new LazyValue<>(() -> {
+        // Note that Mutiny.SessionFactory is @ApplicationScoped bean - it's safe to use the cached client proxy
+        Mutiny.SessionFactory sessionFactory = Arc.container().instance(Mutiny.SessionFactory.class).get();
+        if (sessionFactory == null) {
+            throw new IllegalStateException("Mutiny.SessionFactory bean not found");
+        }
+        return sessionFactory;
+    });
 
-    private static final LazyValue<Key<Mutiny.Session>> SESSION_KEY = new LazyValue<>(
-            new Supplier<Key<Mutiny.Session>>() {
-
-                @Override
-                public Key<Session> get() {
-                    Implementor implementor = (Implementor) ClientProxy.unwrap(SESSION_FACTORY.get());
-                    return new BaseKey<>(Mutiny.Session.class, implementor.getUuid());
-                }
-            });
+    private static final LazyValue<Key<Mutiny.Session>> SESSION_KEY = new LazyValue<>(() -> {
+        Implementor implementor = (Implementor) ClientProxy.unwrap(SESSION_FACTORY.get());
+        return new BaseKey<>(Mutiny.Session.class, implementor.getUuid());
+    });
 
     // This key is used to indicate that a reactive session should be opened lazily (when needed) in the current vertx context
-    private static final String SESSION_ON_DEMAND_KEY = "hibernate.reactive.panache.sessionOnDemand";
-    private static final String SESSION_ON_DEMAND_OPENED_KEY = "hibernate.reactive.panache.sessionOnDemandOpened";
+    private static final Key<Boolean> SESSION_ON_DEMAND_KEY = new BaseKey<>(Boolean.class, "hibernate.reactive.panache.sessionOnDemand");
+    private static final Key<Boolean> SESSION_ON_DEMAND_OPENED_KEY = new BaseKey<>(Boolean.class, "hibernate.reactive.panache.sessionOnDemandOpened");
 
     /**
      * Marks the current vertx duplicated context as "lazy" which indicates that a reactive session should be opened lazily if
@@ -63,17 +55,17 @@ public final class SessionOperations {
      * @see #getSession()
      */
     static <T> Uni<T> withSessionOnDemand(Supplier<Uni<T>> work) {
-        Context context = vertxContext();
-        if (context.getLocal(SESSION_ON_DEMAND_KEY) != null) {
+        Map<Key<Boolean>, Boolean> contextualDataMap = contextualDataMap(vertxContext());
+        if (contextualDataMap.get(SESSION_ON_DEMAND_KEY) != null) {
             // context already marked - no need to set the key and close the session
             return work.get();
         } else {
             // mark the lazy session
-            context.putLocal(SESSION_ON_DEMAND_KEY, true);
+            contextualDataMap.put(SESSION_ON_DEMAND_KEY, Boolean.TRUE);
             // perform the work and eventually close the session and remove the key
             return work.get().eventually(() -> {
-                context.removeLocal(SESSION_ON_DEMAND_KEY);
-                context.removeLocal(SESSION_ON_DEMAND_OPENED_KEY);
+                contextualDataMap.remove(SESSION_ON_DEMAND_KEY);
+                contextualDataMap.remove(SESSION_ON_DEMAND_OPENED_KEY);
                 return closeSession();
             });
         }
@@ -109,9 +101,9 @@ public final class SessionOperations {
      * @return a new {@link Uni}
      */
     public static <T> Uni<T> withSession(Function<Mutiny.Session, Uni<T>> work) {
-        Context context = vertxContext();
+        Map<Key<Session>, Session> contextualDataMap = SessionOperations.<Session> contextualDataMap(vertxContext());
         Key<Mutiny.Session> key = getSessionKey();
-        Mutiny.Session current = context.getLocal(key);
+        Mutiny.Session current = contextualDataMap.get(key);
         if (current != null && current.isOpen()) {
             // reactive session exists - reuse this session
             return work.apply(current);
@@ -119,7 +111,7 @@ public final class SessionOperations {
             // reactive session does not exist - open a new one and close it when the returned Uni completes
             return getSessionFactory()
                     .openSession()
-                    .invoke(s -> context.putLocal(key, s))
+                    .invoke(s -> contextualDataMap.put(key, s))
                     .chain(work::apply)
                     .eventually(SessionOperations::closeSession);
         }
@@ -140,22 +132,24 @@ public final class SessionOperations {
      * @return the {@link Mutiny.Session}
      */
     public static Uni<Mutiny.Session> getSession() {
-        Context context = vertxContext();
+        ContextInternal context = vertxContext();
         Key<Mutiny.Session> key = getSessionKey();
-        Mutiny.Session current = context.getLocal(key);
+        final Mutiny.Session current = SessionOperations.<Session> contextualDataMap(context).get(key);
+        final Map<Key<Boolean>, Boolean> objectsDataMap = contextualDataMap(context);
         if (current != null && current.isOpen()) {
             // reuse the existing reactive session
             return Uni.createFrom().item(current);
         } else {
-            if (context.getLocal(SESSION_ON_DEMAND_KEY) != null) {
-                if (context.getLocal(SESSION_ON_DEMAND_OPENED_KEY) != null) {
+            if (objectsDataMap.get(SESSION_ON_DEMAND_KEY) != null) {
+                if (objectsDataMap.get(SESSION_ON_DEMAND_OPENED_KEY) != null) {
                     // a new reactive session is opened in a previous stage
                     return Uni.createFrom().item(SessionOperations::getCurrentSession);
                 } else {
                     // open a new reactive session and store it in the vertx duplicated context
                     // the context was marked as "lazy" which means that the session will be eventually closed
-                    context.putLocal(SESSION_ON_DEMAND_OPENED_KEY, true);
-                    return getSessionFactory().openSession().invoke(s -> context.putLocal(key, s));
+                    objectsDataMap.put(SESSION_ON_DEMAND_OPENED_KEY, Boolean.TRUE);
+                    return getSessionFactory().openSession().invoke(s -> SessionOperations
+                            .<Session> contextualDataMap(context).put(key, s));
                 }
             } else {
                 throw new IllegalStateException("No current Mutiny.Session found"
@@ -170,12 +164,19 @@ public final class SessionOperations {
      * @return the current reactive session stored in the context, or {@code null} if no session exists
      */
     public static Mutiny.Session getCurrentSession() {
-        Context context = vertxContext();
-        Mutiny.Session current = context.getLocal(getSessionKey());
+        Mutiny.Session current = SessionOperations.<Session> contextualDataMap(vertxContext()).get(getSessionKey());
         if (current != null && current.isOpen()) {
             return current;
         }
         return null;
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    private static <T> Map<Key<T>, T> contextualDataMap(ContextInternal vertxContext) {
+        return vertxContext.getLocal(
+                ContextualDataStorage.CONTEXTUAL_DATA_KEY,
+                AccessMode.CONCURRENT,
+                ConcurrentHashMap::new);
     }
 
     /**
@@ -184,9 +185,10 @@ public final class SessionOperations {
      * @throws IllegalStateException If no vertx context is found or is not a safe context as mandated by the
      *         {@link VertxContextSafetyToggle}
      */
-    private static Context vertxContext() {
-        Context context = Vertx.currentContext();
+    private static ContextInternal vertxContext() {
+        ContextInternal context = ContextInternal.current();
         if (context != null) {
+            // TODO: Update check for ContextItnernal
             VertxContextSafetyToggle.validateContextIfExists(ERROR_MSG, ERROR_MSG);
             return context;
         } else {
@@ -195,11 +197,11 @@ public final class SessionOperations {
     }
 
     static Uni<Void> closeSession() {
-        Context context = vertxContext();
         Key<Mutiny.Session> key = getSessionKey();
-        Mutiny.Session current = context.getLocal(key);
+        Map<Key<Session>, Session> contextualDataMap = contextualDataMap(vertxContext());
+        Mutiny.Session current = contextualDataMap.get(key);
         if (current != null && current.isOpen()) {
-            return current.close().eventually(() -> context.removeLocal(key));
+            return current.close().eventually(() -> contextualDataMap.remove(key));
         }
         return Uni.createFrom().voidItem();
     }

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-dev-services.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-dev-services.js
@@ -155,6 +155,7 @@ export class QwcDevServices extends observeState(QwcHotReloadElement) {
             let ports = devService.containerInfo.exposedPorts;
             
             const p = ports
+                .filter(p => p.publicPort != null)
                 .map(p => p.ip + ":" + p.publicPort + "->" + p.privatePort + "/" + p.type)
                 .join(', ');
 

--- a/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/Counter.java
+++ b/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/Counter.java
@@ -1,0 +1,37 @@
+package io.quarkus.it.panache.reactive;
+
+import io.quarkus.hibernate.reactive.panache.PanacheEntityBase;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class Counter extends PanacheEntityBase {
+
+    @Id
+    private Long id;
+    private int count = 0;
+
+    public Counter() {
+    }
+
+    public Counter(long id) {
+        this.id = id;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(count);
+    }
+
+    public void increase() {
+        this.count++;
+    }
+}

--- a/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/WithTransactionCounterBean.java
+++ b/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/WithTransactionCounterBean.java
@@ -1,0 +1,68 @@
+package io.quarkus.it.panache.reactive;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import org.junit.jupiter.api.Assertions;
+
+import io.quarkus.hibernate.reactive.panache.Panache;
+import io.quarkus.hibernate.reactive.panache.common.WithTransaction;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static jakarta.persistence.LockModeType.PESSIMISTIC_WRITE;
+
+/**
+ * The goal if this class is to test the usage of {@link WithTransaction},
+ * you should not use {@link io.quarkus.hibernate.reactive.panache.Panache#withTransaction(Supplier)}
+ * nor {@link org.hibernate.reactive.mutiny.Mutiny.SessionFactory#withTransaction(Function)}
+ */
+@ApplicationScoped
+@WithTransaction
+public class WithTransactionCounterBean {
+
+    private static final Long ID_COUNTER = 42L;
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    public Uni<Counter> createOrResetCounter() {
+        final Counter counter = new Counter(ID_COUNTER);
+        return sessionFactory.withStatelessSession(session -> session
+                .upsert(counter)
+                .replaceWith(counter)
+        );
+    }
+
+    public Uni<Counter> increaseCounterWithHR() {
+        return sessionFactory.withSession(session -> session
+                .find(Counter.class, ID_COUNTER, PESSIMISTIC_WRITE)
+                .invoke(Counter::increase)
+        );
+    }
+
+    public Uni<Counter> increaseCounterWithPanache() {
+        return Counter
+                .<Counter> findById(ID_COUNTER, PESSIMISTIC_WRITE)
+                .invoke(Counter::increase);
+    }
+
+    public Uni<Void> assertThatSessionsAreEqual() {
+        return sessionFactory.withSession(hrSession -> Panache
+                .getSession().chain(panacheSession -> {
+                    if (panacheSession != hrSession) {
+                        return Uni.createFrom().failure(new AssertionError("Sessions are different!"));
+                    }
+                    return Uni.createFrom().voidItem();
+                })
+        );
+    }
+
+    public Uni<Counter> findCounter() {
+        return sessionFactory.withSession(session -> session
+                .find(Counter.class, ID_COUNTER)
+        );
+    }
+}

--- a/integration-tests/hibernate-reactive-panache/src/main/resources/application.properties
+++ b/integration-tests/hibernate-reactive-panache/src/main/resources/application.properties
@@ -4,3 +4,9 @@ quarkus.datasource.password=hibernate_orm_test
 quarkus.datasource.reactive.url=${postgres.reactive.url}
 
 quarkus.hibernate-orm.database.generation=drop-and-create
+
+quarkus.log.category."org.hibernate.reactive.context".level=TRACE
+
+quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.log.format-sql=false
+quarkus.hibernate-orm.log.highlight-sql=true

--- a/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/WithTransactionTest.java
+++ b/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/WithTransactionTest.java
@@ -1,0 +1,83 @@
+package io.quarkus.it.panache.reactive;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static io.quarkus.vertx.VertxContextSupport.subscribeAndAwait;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Hibernate Reactive and Panache store the created sessions in a local Vert.x context,
+ * and we need to make sure that they won't get lost.
+ * See issue <a href="https://github.com/quarkusio/quarkus/issues/47314">47314</a>
+ *
+ * @see io.quarkus.hibernate.reactive.panache.common.runtime.SessionOperations
+ * @see io.quarkus.hibernate.reactive.panache.common.WithTransaction
+ */
+@QuarkusTest
+public class WithTransactionTest {
+    // How many times we want to increase the counter
+    private static final int INCREASES_NUM = 10;
+
+    @Inject
+    WithTransactionCounterBean counterBean;
+
+    @BeforeEach
+    public void createOrResetCounter() throws Throwable {
+        subscribeAndAwait(counterBean::createOrResetCounter);
+    }
+
+    @Test
+    void increaseCounterWithHibernateReactive() throws Throwable {
+        subscribeAndAwait(counterBean::increaseCounterWithHR);
+        Counter counter = subscribeAndAwait(counterBean::findCounter);
+
+        assertThat(counter.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    void increaseCounterWithPanache() throws Throwable {
+        subscribeAndAwait(counterBean::increaseCounterWithPanache);
+        Counter counter = subscribeAndAwait(counterBean::findCounter);
+
+        assertThat(counter.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldReuseExistingSessions() throws Throwable {
+        subscribeAndAwait(counterBean::assertThatSessionsAreEqual);
+    }
+
+    @Test
+    void increaseCounter() throws Throwable {
+        List<Supplier<Uni<Counter>>> suppliers = new ArrayList<>();
+        for (int i = 0; i < INCREASES_NUM; i++) {
+            suppliers.add(() -> counterBean.increaseCounterWithHR());
+        }
+
+        final List<Counter> results = new ArrayList<>();
+        suppliers.stream()
+                .parallel()
+                .forEach(uni -> increaseCounter(uni, results));
+
+        final Counter dbCounter = subscribeAndAwait(() -> counterBean.findCounter());
+        assertThat(dbCounter.getCount()).isEqualTo(INCREASES_NUM);
+    }
+
+    private static void increaseCounter(Supplier<Uni<Counter>> func, List<Counter> counters) {
+        try {
+            final var counter = subscribeAndAwait(func);
+            counters.add(counter);
+        } catch (final Throwable e) {
+            fail(e);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <antlr.version>4.13.0</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
         <bytebuddy.version>1.15.11</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>7.0.3.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM's needs -->
-        <hibernate-reactive.version>2.4.7-SNAPSHOT</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
+        <hibernate-reactive.version>2.4.7.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>8.0.2.Final</hibernate-validator.version>
         <hibernate-search.version>7.2.3.Final</hibernate-search.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <antlr.version>4.13.0</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
         <bytebuddy.version>1.15.11</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>7.0.3.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM's needs -->
-        <hibernate-reactive.version>2.4.6.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
+        <hibernate-reactive.version>2.4.7-SNAPSHOT</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>8.0.2.Final</hibernate-validator.version>
         <hibernate-search.version>7.2.3.Final</hibernate-search.version>
 


### PR DESCRIPTION
Possible fix for https://github.com/quarkusio/quarkus/issues/47314
Requires Hibernate Reactive 2.4.7.Final (probably)